### PR TITLE
Fix space before parentheses

### DIFF
--- a/src/components/Parts/Redirects.vue
+++ b/src/components/Parts/Redirects.vue
@@ -1,6 +1,6 @@
 <template>
   <tbl
-    :headline="$t('rt.redirects') + '(' + redirects.length + ')'"
+    :headline="`${$t('rt.redirects')} (${redirects.length})`"
     :columns="columns"
     :rows="redirects"
     :is-loading="$store.state.isLoading"


### PR DESCRIPTION
Add space before parentheses to match the **Fails**  tab.

<img width="237" alt="retour" src="https://user-images.githubusercontent.com/688309/54204331-cd417f80-44b2-11e9-97dd-aaabf5969eea.png">
