### PR TITLE
Update FR menu label

### DIFF
--- a/src/config/i18n/fr.php
+++ b/src/config/i18n/fr.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'view.retour' => 'Retour',
+    'view.retour' => 'Redirections',
 
     'retour.tbl.all'             => 'Tout',
     'retour.tbl.filter'          => 'Filtrer...',


### PR DESCRIPTION
It's my own fault when I first translated the plugin, but: _Retour_ in french literally means _Back_. 
The wording is therefore a bit confusing to have in a menu. I have updated it in my project but also think it'd be clearer for a broader use. 