### PR TITLE
Fix variable declaration

### DIFF
--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -36,7 +36,7 @@ export default {
 
       // failures
       if (store.system.hasLog) {
-        const failures = store.data.failures.length;
+        let failures = store.data.failures.length;
 
         if (failures > 1000) {
           failures = (Math.floor(failures / 100) / 10) + "k";


### PR DESCRIPTION
If the log contains more the 1000 failures the loading of settings page failed.

Cause of this issue is a wrong variable declaration. This PR fix this issue.