### PR TITLE
Fix for routes that don’t return strings

### DIFF
--- a/src/extensions/hooks.php
+++ b/src/extensions/hooks.php
@@ -21,7 +21,7 @@ return [
         Route $route,
         string $path,
         string $method,
-        string $result = null,
+        $result = null,
         bool $final
     ) {
         if (


### PR DESCRIPTION
router:after gets various types supplied as 4th parameter so we don’t do type checking here.

Closes #275