### PR TITLE
Fix for 404 Error on "Add as redirect" in Failures

### DIFF
--- a/src/extensions/dialogs.php
+++ b/src/extensions/dialogs.php
@@ -139,7 +139,7 @@ return [
             'props' => [
                 'fields' => $fields(Retour::instance()),
                 'value' => [
-                    'from' => urldecode($path)
+                    'from' => str_replace("\x1D",'/', urldecode($path))
                 ],
                 'size'  => 'large'
             ]

--- a/src/panel/components/Tabs/FailuresTab.vue
+++ b/src/panel/components/Tabs/FailuresTab.vue
@@ -62,7 +62,7 @@ export default {
   },
   methods: {
     onOption(option, row) {
-      const path = encodeURIComponent(row.path);
+      const path = encodeURIComponent(row.path.replace(/\//g, "\x1D"));
       return this.$dialog(`retour/failures/${path}/${option}`);
     },
   },


### PR DESCRIPTION
Fixes #307 

This fix depends on #305 which fixed #300. However it didn't address the same issue when adding as redirect from `Failures` tab.

## Proposed Changes

Replace forward-slash with the non-visible ASCII character "GROUP-SEPARATOR"

  - in `src/panel/components/Tabs/FailuresTab.vue`
  - in `src/extensions/dialogs.php`

