### PR TITLE
Feature: Also be compatibe with Kirby 3.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
         }
     ],
     "require": {
-        "php": ">=8.0.0 <8.2.0",
+        "php": ">=8.0.0 <8.3.0",
         "ext-json": "*",
-        "getkirby/cms": ">=3.7.4 <3.9.0",
+        "getkirby/cms": ">=3.7.4 <4.0",
         "getkirby/composer-installer": "^1.1"
     },
     "autoload-dev": {


### PR DESCRIPTION
## Proposed Changes
As Kirby 3.9 is released and there are no breaking changes; I suggest we change the require kirby to <4. I also don't see why this package wouldn't work with PHP8.2; also there are no breaking changes.