### PR TITLE
Feature: Let composer now package is only for Kirby4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "php": ">=8.1.0 <8.4.0",
+        "getkirby/cms": "^4.0",
         "getkirby/composer-installer": "^1.1"
     },
     "autoload-dev": {


### PR DESCRIPTION
With the release of Retour 5 (Yay!), it should be noted that, at the moment, it's possible to install this into a KirbyCMS ^3.0 project. For example, we use Renovate to automatically update dependencies for us, and without this change, the system sees this as an opportunity to upgrade to v5. Adding just this line of code prevents installing Retour v5 on Kirby3 versions.