### PR TITLE
Fix link to docs for placeholders and status codes

### DIFF
--- a/src/Retour/Panel/RedirectCreateDrawer.php
+++ b/src/Retour/Panel/RedirectCreateDrawer.php
@@ -44,7 +44,7 @@ class RedirectCreateDrawer
 				'counter'  => false,
 				'required' => true,
 				'help'     => I18n::template('retour.redirects.from.help', [
-					'docs' => 'https://github.com/distantnative/retour-for-kirby#path'
+					'docs' => 'https://distantnative.com/retour-for-kirby/redirects#path'
 				])
 			],
 			'to' => [
@@ -59,7 +59,7 @@ class RedirectCreateDrawer
 				'options'  => $codes,
 				'width'    => '1/2',
 				'help'     => I18n::template('retour.redirects.status.help', [
-					'docs' => 'https://github.com/distantnative/retour-for-kirby#status'
+					'docs' => 'https://distantnative.com/retour-for-kirby/redirects#status'
 				])
 			],
 			'priority' => [


### PR DESCRIPTION
The links in the help texts for "Path" and "Status" were both wrong. I guess the anchors were previously in the README and are now in the docs?