### PR TITLE
Support Kirby 5.0 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Manage redirects and track 404s right from the Kirby CMS Panel",
 	"license": "MIT",
 	"type": "kirby-plugin",
-	"version": "5.3.1",
+	"version": "5.3.2",
 	"homepage": "https://distantnative.com/retour-for-kirby/",
 	"authors": [
 		{
@@ -13,7 +13,7 @@
 	],
 	"require": {
 		"php": ">=8.1.0 <8.4.0",
-		"getkirby/cms": "^4.3.1",
+		"getkirby/cms": "^4.3.1 || ^5.0",
 		"getkirby/composer-installer": "^1.1"
 	},
 	"autoload-dev": {


### PR DESCRIPTION
# Fixes
Adds support for Kirby 5.0 in composer.json requirements to allow testing with Kirby 5 pre-release versions.

